### PR TITLE
Fix internal structure of zip archive (created during workflow)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build Dictionary
         run: |
           ./build.sh
-          zip -9 -r KLM.dictionary.zip objects/target/KLM.dictionary
+          (cd objects/target && zip -9 -r ../../KLM.dictionary.zip KLM.dictionary)
       - uses: actions/upload-artifact@v3
         with:
           name: KLM.dictionary


### PR DESCRIPTION
v4 was broken:
```
x objects/target/KLM.dictionary/
x objects/target/KLM.dictionary/Contents/
x objects/target/KLM.dictionary/Contents/KeyText.data
x objects/target/KLM.dictionary/Contents/EntryID.data
x objects/target/KLM.dictionary/Contents/DefaultStyle.css
x objects/target/KLM.dictionary/Contents/KeyText.index
x objects/target/KLM.dictionary/Contents/Info.plist
x objects/target/KLM.dictionary/Contents/EntryID.index
x objects/target/KLM.dictionary/Contents/Body.data
```